### PR TITLE
Minor updates to README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,31 +1,38 @@
 
+magicsuper: backport of Python 3 ``super()`` to Python 2
+=========================================================================
 
-magicsuper:  backport the magical zero-argument super() to python2
-=================================================================
+This is an (awful, hacky, WTF-were-you-thinking) attempt to port the magical
+zero-argument ``super()`` call from Python 3 to Python 2.
 
-This is an (awful, hacky, wtf-were-you-thinking) attempt to port the magical
-zero-argument super() call from python3 to python2.
-
-In standard python2 usage of the super() builtin, you have to repeat both the
-class and instance objects when you call super, like this:
+In standard Python 2, you have to repeat both the
+class and instance objects when calling ``super()``—like this:
 
     class Hello(Base):
         def hello(self):
             super(Hello,self).hello()
 
-Using magicsuper, you can get the friendlier behaviour from python3 where it
+Using ``magicsuper``, you can get the friendlier behaviour from Python 3, which
 just figures out the correct call at runtime:
 
     class Hello(Base):
         def hello(self):
             super().hello()
 
-Of course, you can still explicitly pass in the arguments if you want to do
-something strange.  Sometimes you really do want that, e.g. to skip over
+Of course, you can still explicitly pass in the arguments if you *want* to do
+something strange.  Sometimes it’s desirable—for example, to skip over
 some classes in the method resolution order.
 
-How does it work?  By inspecting the calling frame to determine the function
-object being executed and the object on which it's being called, and then
-walking the object's __mro__ chain to find out where that function was
-defined.  Yuck, but it seems to work...
+
+How does it work?  
+-----------------
+
+By inspecting the calling frame to:
+
+- determine the function object being executed
+- determine the object on which it’s being called, and then
+- walking the object’s ``__mro__`` chain to find out where that function was
+defined.  
+
+Yuck, but it seems to work...
 


### PR DESCRIPTION
- markup inline literals (double-backtick) where appropriate
- tweaked text for phrasing, clarity
- made “How does it work?” its own section, and formatted as bullet list to make it easy to scan and understand

After all, Pythonistas used to version 2 are **not** expecting `super()` to be simple; they’ll probably want to know what black magic made this possible.  ☺ 

However: I, for one, am `super()` excited to see this backport.  I have no negative feelings about its “hacky” nature. I think it’s a totally appropriate trade for devs wanting to read and write code that is more intuitive.  Can’t wait to try it out! :)
