### PR TITLE
Added encoding comment to `__init__.py`

### DIFF
--- a/magicsuper/__init__.py
+++ b/magicsuper/__init__.py
@@ -1,5 +1,5 @@
-"""
-
+# -*- coding: utf-8 -*-
+'''
 magicsuper:  backport the magical zero-argument super() to python2
 =================================================================
 
@@ -29,8 +29,7 @@ object being executed and the object on which it's being called, and then
 walking the object's __mro__ chain to find out where that function was
 defined.  Yuck, but it seems to work...
 
-"""
-
+'''
 
 __ver_major__ = 0
 __ver_minor__ = 2


### PR DESCRIPTION
It’s unofficial, but it’s a good practice and common convention.

Many editors look for a comment like this to help determine a file’s encoding.  (If there had been a shebang—typically seen as `#!/usr/bin/env python`—then the encoding comment immediately follows it.)
